### PR TITLE
Update text.simba

### DIFF
--- a/SRL/core/text.simba
+++ b/SRL/core/text.simba
@@ -1066,7 +1066,6 @@ Will default to 'all'.
 
     by Wizzup? & Nava2 & N1ke!
     Last Modified: 22/12/12 by riwu
-                   Slushpuppy - 03 march 13
 
 Example:
 
@@ -1095,12 +1094,10 @@ begin
       R:= Min(((B.X2 - B.X1) shr 1), 5); //Prevents x2 passed to MouseBoxEx being smaller than x1
       case Action of
         ClickLeft:
-           begin
           if PointInBox(T, B) then
             ClickMouse2(true)
           else
-            MouseBoxEx(T.x+ B.x1 + R,  T.y+B.Y1 + 20, T.x+B.x2 - R, T.y+B.Y1 + 40, R, mouse_left);
-          end;
+            MouseBoxEx(B.x1 + R, B.Y1, B.x2 - R, B.Y1 + 5, R, mouse_Left);
         Move:
           if not PointInBox(T, B) then
             MouseBoxEx(B.x1 + R, B.Y1, B.x2 - R, B.Y1 + 5, R, mouse_move);


### PR DESCRIPTION
slushpuppy had committed a line in ChooseOptionMultiEx (specifically the ClickLeft case action), in which broke the use-ability for ``child'' functions.  The code is reverted back to what works properly, and should probably stay as is next time unless there's a conflict with something specific on slushpuppy's/anyone else's end aside from saying it's fixed (in my opinion). :)
