### PR TITLE
Update bank.simba

### DIFF
--- a/SRL/core/bank.simba
+++ b/SRL/core/bank.simba
@@ -777,8 +777,6 @@ begin
     begin
       If Not ExistsItem(I) Then
         Continue;
-      if GetAmountBox(InvBox(I)) <= 1 then
-         MouseItem(I, mouse_left) else
       if (not All) then
         MouseItem(I, mouse_left)
       else


### PR DESCRIPTION
removed that thing that checks for item amount in inventory slot. What if you are depositing an inventory of a bunch of logs? Was causing it to click it one by one.
