### PR TITLE
simple offset fix

### DIFF
--- a/SRL/core/chat.simba
+++ b/SRL/core/chat.simba
@@ -351,7 +351,7 @@ Example:
 function TextCoords(textn: Integer): TPoint;
 begin
   Result.X := 15;
-  Result.Y := 351 + (14 * (textn - 1));
+  Result.Y := 347 + (14 * (textn - 1));
 end;
 
 (*


### PR DESCRIPTION
..::Fixed::.. -> TextCoords function, simply -4 to the result.y, so the text lined up correctly.
Can see previous discussion here: http://villavu.com/forum/showthread.php?t=97281 - posts 56 to 62.

Reason why it might have changed? (Don't honestly know)
I assume there was an adjustment in-game to the chat box, or the get chat messages were never tested, or there was a change at one point somewhere..
