### PR TITLE
SetScreenName check/fail safe

### DIFF
--- a/SRL/core/antirandoms/antirandoms.simba
+++ b/SRL/core/antirandoms/antirandoms.simba
@@ -408,13 +408,16 @@ end;
 
 {*******************************************************************************
 procedure SetScreenName(ScreenName: String);
-by: WT-Fakawi edited by Ashaman88
+by: WT-Fakawi edited by Ashaman88, Justin
 Description: Sets screenname for use with FindTalk and one Player.
 *******************************************************************************}
 
 procedure SetScreenName(ScreenName: string);
 begin
-  NickNameBMP := BitmapFromText(ScreenName, upchars07);
+  if (ScreenName = '') then
+    Exit;
+
+  NickNameBMP := BitmapFromText(ScreenName, UpChars07);
 
   if (not NicknameSet) then
     AddOnTerminate('FreeScreenName');


### PR DESCRIPTION
Requested via Justin.

Checks if the arg ScreeName: string is empty, if so, exiting before needless calls.
