### PR TITLE
Update antirandoms.simba

### DIFF
--- a/SRL/core/antirandoms/antirandoms.simba
+++ b/SRL/core/antirandoms/antirandoms.simba
@@ -1048,7 +1048,7 @@ begin
 
       // solve reward box if a non inventory random was just solved
       if (loggedIn()) then // if solver failed, player would be logged out
-        if (not SRL_Randoms[i].isInvRandom) then
+        if ((not SRL_Randoms[i].isInvRandom) and checkInv) then
         begin
           // reward box doesn't exist if inventory is full/some randoms don't have reward box
           result := (invFull() or (not SRL_Randoms[i].hasRewardBox));


### PR DESCRIPTION
FindNonInventoryRandoms was still forcing a gametab to the inventory for solved non-inventory randoms with a rewards box (even if checkInv was false)
In response to Haxz' post on Villa: https://villavu.com/forum/showthread.php?t=97757&p=1298325#post1298325
