### PR TITLE
Fixed compiling with Lape

### DIFF
--- a/SRL/core/antirandoms/evilbob.simba
+++ b/SRL/core/antirandoms/evilbob.simba
@@ -280,6 +280,7 @@ begin
 end;
 
 {$IFNDEF SIMBAMAJOR1000}
+{$IFNDEF LAPE}
 (**
  * Author: riwu
  * Description: Sort TPAs into 2D TPAs through deduction, based on size and min count.
@@ -291,6 +292,7 @@ begin
   SortTPAFrom(TPA, Point(0, 0));
   Result := TPA[Length(TPA) shr 1];
 end;
+{$ENDIF}
 {$ENDIF}
 
 (**

--- a/SRL/core/simba.simba
+++ b/SRL/core/simba.simba
@@ -161,10 +161,12 @@ type
   TDTMPointDefArray = TSDTMPointDefArray;
   TDTM = TSDTM;
 
+{$IFNDEF LAPE}
 function AddDTM(DTM : TDTM) : integer;
 begin
   Result := AddSDTM(dtm);
 end;
+{$ENDIF}
 
 {$ENDIF}
 
@@ -449,6 +451,7 @@ begin;
 end;
 
 {$IFNDEF SIMBAMAJOR1000}
+{$IFNDEF LAPE}
 function AddOnTerminate(const proc : string) : boolean;
 var
   OldProcs : TVariantArray;
@@ -483,6 +486,7 @@ begin
     end;
   SetScriptProp(SP_OnTerminate,NewProcs);
 end;
+{$ENDIF}
 {$ENDIF}
 
 function Readln(Question : string ) : string;

--- a/SRL/core/text.simba
+++ b/SRL/core/text.simba
@@ -888,6 +888,7 @@ begin
 end;
 
 {$IFNDEF SIMBAMAJOR1000}
+{$IFNDEF LAPE}
 (*
 SortATPAFromFirstPointY
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -967,6 +968,7 @@ begin
 
   QuickATPASort(DistArr, a, 0, l, True);
 end;
+{$ENDIF}
 {$ENDIF}
 
 (*


### PR DESCRIPTION
Added a few `{$IFNDEF LAPE}`'s for functions that were throwing
duplicate declaration errors.